### PR TITLE
Correct case of *.png in options.html

### DIFF
--- a/options.html
+++ b/options.html
@@ -44,7 +44,7 @@
 					</form>
 				<p><strong>CutSpel</strong> can be turned on or off for any webpage 
 				by clicking on the <strong>CutSpel Toolbar Icon</strong>.<br>
-				 <img src="on.png" width="16" height="16">ON  &nbsp; &nbsp;<img src="off.png" width="16" height="16">OFF</p>
+				 <img src="ON.png" width="16" height="16">ON  &nbsp; &nbsp;<img src="OFF.png" width="16" height="16">OFF</p>
 				</div>
 			</div>
 		<div>


### PR DESCRIPTION
Previously, the options page for CutSpel from the chrome extension dies with "This extension may have been corrupted.", and the extension is disabled.  The cause is a simple case difference in the file name, corrected here.  This error does not occur when you load the extension from a local directory, on a mac at least.